### PR TITLE
Make sure num framebuffers quirk is enabled (fixes: https://github.co…

### DIFF
--- a/usc-wrapper
+++ b/usc-wrapper
@@ -5,4 +5,4 @@
 . /etc/environment
 export ANDROID_ROOT
 
-exec unity-system-compositor --disable-overlays=false --spinner=$SNAP/usr/bin/unity-system-compositor-spinner $@
+exec unity-system-compositor --enable-num-framebuffers-quirk=true --disable-overlays=false --spinner=$SNAP/usr/bin/unity-system-compositor-spinner $@


### PR DESCRIPTION
…m/ubports/ubuntu-touch/issues/696)

This makes sure num framebuffers quirk is enabled, this is enabled by default anyway in mir, but not in usc for some reason. Reason why this has worked before is that lighdm should spawn a mir server, but for some reason it does not do on luxembourg timezone. The issue is still a mystery, but this fixes the issue.