### PR TITLE
Use deviceinfo to set device specific environment variables

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,7 @@ Package: ubuntu-touch-session-mir
 Architecture: all
 Depends: ubuntu-touch-session (= ${binary:Version}),
          unity-system-compositor (>= 0.0.3),
+         deviceinfo-tools
 Conflicts: ubuntu-touch-session-wayland
 Description: Mir on Mir session using unity-system-compositor
  Mir on Mir session using unity-system-compositor
@@ -37,7 +38,8 @@ Description: Mir on Mir session using unity-system-compositor
 Package: ubuntu-touch-session-wayland
 Architecture: all
 Depends: ubuntu-touch-session (= ${binary:Version}),
-         qtwayland5
+         qtwayland5,
+         deviceinfo-tools
 Conflicts: ubuntu-touch-session-mir
 Description: Wayland session without using mir on mir
  Wayland session without using mir on mir

--- a/mir-session/ubuntu-touch-session
+++ b/mir-session/ubuntu-touch-session
@@ -7,18 +7,10 @@
 
 export QT_QPA_PLATFORM=ubuntumirclient
 
-# defaults
-GRID_UNIT_PX=18
-QTWEBKIT_DPR=2.0
-NATIVE_ORIENTATION=portrait
-
-# override defaults by sourcing /etc/ubuntu-touch-session.d/$device.conf
-device=$(getprop ro.product.device)
-if [ -e $SNAP/etc/ubuntu-touch-session.d/$device.conf ]; then
-    . $SNAP/etc/ubuntu-touch-session.d/$device.conf
-else
-    # android.conf is used by the bind mount
-    . $SNAP/etc/ubuntu-touch-session.d/android.conf
+if [ -x "$(command -v device-info)" ]; then
+    GRID_UNIT_PX=$(device-info get GridUnit)
+    QTWEBKIT_DPR=$(device-info get WebkitDpr)
+    NATIVE_ORIENTATION=$(device-info get PrimaryOrientation)
 fi
 
 # Workaround for bug 1308210 / 1318070 (x86 emulator and scopes)

--- a/wayland-session/ubuntu-touch-session
+++ b/wayland-session/ubuntu-touch-session
@@ -8,18 +8,10 @@
 export QT_QPA_PLATFORM=wayland
 export QT_WAYLAND_DISABLE_WINDOWDECORATION=1
 
-# defaults
-GRID_UNIT_PX=18
-QTWEBKIT_DPR=2.0
-NATIVE_ORIENTATION=portrait
-
-# override defaults by sourcing /etc/ubuntu-touch-session.d/$device.conf
-device=$(getprop ro.product.device)
-if [ -e $SNAP/etc/ubuntu-touch-session.d/$device.conf ]; then
-    . $SNAP/etc/ubuntu-touch-session.d/$device.conf
-else
-    # android.conf is used by the bind mount
-    . $SNAP/etc/ubuntu-touch-session.d/android.conf
+if [ -x "$(command -v device-info)" ]; then
+    GRID_UNIT_PX=$(device-info get GridUnit)
+    QTWEBKIT_DPR=$(device-info get WebkitDpr)
+    NATIVE_ORIENTATION=$(device-info get PrimaryOrientation)
 fi
 
 # Workaround for bug 1308210 / 1318070 (x86 emulator and scopes)


### PR DESCRIPTION
As deviceinfo does not have tests yet, its not ready for devel. so lets use edge to test it.

Needed for mainline things as there is no getprop. 