### PR TITLE
Prevent dbus race condition eating 'android' event

### DIFF
--- a/no-android.conf
+++ b/no-android.conf
@@ -1,4 +1,4 @@
-start on startup
+start on started dbus
 
 pre-start script
         if [ ! -f /var/lib/lxc/android/config ]; then


### PR DESCRIPTION
This 'initctl emit' command occasionally ran before the dbus system bus was up. When this happened, the emitted event was lost and init did not continue.